### PR TITLE
Switch to Coursier resolver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,9 +3,7 @@ name := "slick-cats"
 description := "cats and slick"
 
 scalaVersion := "2.12.2"
-
 crossScalaVersions := Seq("2.11.11", "2.12.2")
-releaseCrossBuild := true
 
 scalacOptions ++= Seq(
   "-deprecation",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.5")
-addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.5.1")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC3")
+addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.5.2")
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")


### PR DESCRIPTION
Also:

* removes redundant `sbt-release` plugin;
*  bumps up `tut-plugin`.

Ready for publishing with `sbt clean +publish`.