### PR TITLE
Update cats to 2.2.0, slick-cats to 0.10.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ Because of possible binary incompatibilities here are the dependency versions us
 |         0.8        |     3.2.3     |     1.2.x     |
 |         0.9.0      |     3.2.3     |     1.5.x     |
 |         0.9.1      |     3.3.0     |     1.5.x     |
-|         0.10.1      |     3.3.2     |     2.0.0     |
-|         0.10.2      |     3.3.2     |     2.1.0     |
+|         0.10.1     |     3.3.2     |     2.0.0     |
+|         0.10.2     |     3.3.2     |     2.1.0     |
+|         0.10.3     |     3.3.2     |     2.2.0     |
 
 Artifacts are publicly available on Maven Central starting from version *0.6*.
 
@@ -50,7 +51,7 @@ Artifacts are publicly available on Maven Central starting from version *0.6*.
 Some or all of the following imports may be needed:
 ```scala
 import cats._
-import cats.implicits._
+import cats.syntax.all._
 import slick.dbio._
 import com.rms.miu.slickcats.DBIOInstances._
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ val commonSettings = Seq(
   )
 )
 
-val catsVersion = "2.1.0"
+val catsVersion = "2.2.0"
 
 lazy val slickcats =
   project.in(file("slick-cats"))

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,9 @@ Because of possible binary incompatibilities here are the dependency versions us
 |         0.8        |     3.2.3     |     1.2.x     |
 |         0.9.0      |     3.2.3     |     1.5.x     |
 |         0.9.1      |     3.3.0     |     1.5.x     |
+|         0.10.1     |     3.3.2     |     2.0.0     |
+|         0.10.2     |     3.3.2     |     2.1.0     |
+|         0.10.3     |     3.3.2     |     2.2.0     |
 
 Artifacts are publicly available on Maven Central starting from version *0.6*.
 
@@ -45,7 +48,7 @@ Artifacts are publicly available on Maven Central starting from version *0.6*.
 Some or all of the following imports may be needed:
 ```scala mdoc:silent
 import cats._
-import cats.implicits._
+import cats.syntax.all._
 import slick.dbio._
 import com.rms.miu.slickcats.DBIOInstances._
 ```

--- a/slick-cats/src/main/scala/com/rms/miu/slickcats/DBIOInstances.scala
+++ b/slick-cats/src/main/scala/com/rms/miu/slickcats/DBIOInstances.scala
@@ -9,7 +9,7 @@
 package com.rms.miu.slickcats
 
 import cats._
-import cats.implicits._
+import cats.syntax.all._
 import slick.basic.BasicBackend
 import slick.dbio._
 

--- a/slick-cats/src/test/scala/com/rms/miu/slickcats/DBIOInstancesTest.scala
+++ b/slick-cats/src/test/scala/com/rms/miu/slickcats/DBIOInstancesTest.scala
@@ -9,7 +9,7 @@
 package com.rms.miu.slickcats
 
 import cats.data.EitherT
-import cats.implicits._
+import cats.syntax.all._
 import cats.instances.AllInstances
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.laws.discipline._

--- a/slick-cats/src/test/scala/com/rms/miu/slickcats/DBIOInstancesTest.scala
+++ b/slick-cats/src/test/scala/com/rms/miu/slickcats/DBIOInstancesTest.scala
@@ -9,10 +9,10 @@
 package com.rms.miu.slickcats
 
 import cats.data.EitherT
-import cats.syntax.all._
 import cats.instances.AllInstances
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.laws.discipline._
+import cats.syntax.all._
 import cats.{Comonad, Eq}
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.{Arbitrary, Cogen, Gen}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.10.2"
+version in ThisBuild := "0.10.3"


### PR DESCRIPTION
A new version of cats is available, with faster compilation times.