### PR TITLE
Scala 3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 SlickCats
-=========
+==========
 
 [Cats](https://github.com/typelevel/cats) instances for [Slick's](http://slick.typesafe.com/) `DBIO` including:
 * Monad
@@ -14,9 +14,7 @@ SlickCats
 * Equals
 
 ## Using
-
 To add *slick-cats* dependency to a project, add the following to your build definition:
-
 ```scala
 libraryDependencies += "com.rms.miu" %% "slick-cats" % version
 ```
@@ -34,18 +32,14 @@ Because of possible binary incompatibilities, here are the dependency versions u
 Artifacts are publicly available on Maven Central starting from version *0.6*.
 
 ## Accessing the Instances
-
 Some or all of the following imports may be needed:
-
 ```scala
 import cats._
 import slick.dbio._
 import com.rms.miu.slickcats.DBIOInstances._
 ```
-
 Additionally, be sure to have an implicit `ExecutionContext` in scope. The implicit conversions require it
 and will fail with non-obvious errors if it's missing.
-
 ```scala
 implicitly[Monad[DBIO]]
 // error: could not find implicit value for parameter e: cats.Monad[slick.dbio.DBIO]
@@ -58,7 +52,6 @@ import scala.concurrent.ExecutionContext.Implicits.global
 ```
 
 instances will be available for:
-
 ```scala
 implicitly[Monad[DBIO]]
 implicitly[MonadError[DBIO, Throwable]]
@@ -68,7 +61,6 @@ implicitly[Applicative[DBIO]]
 ```
 
 If a Monoid exists for `A`, here taken as Int, then the following is also available
-
 ```scala
 implicitly[Group[DBIO[Int]]]
 implicitly[Semigroup[DBIO[Int]]]
@@ -76,7 +68,6 @@ implicitly[Monoid[DBIO[Int]]]
 ```
 
 ## Known Issues
-
 Instances are supplied for `DBIO[A]` only. Despite being the same thing,
 type aliases will not match for implicit conversion. This means that the following
 
@@ -84,15 +75,15 @@ type aliases will not match for implicit conversion. This means that the followi
 def monad[F[_] : Monad, A](fa: F[A]): F[A] = fa
 
 val fail1: DBIOAction[String, NoStream, Effect.All] = DBIO.successful("hello")
-// fail1: DBIOAction[String, NoStream, Effect.All] = SuccessAction("hello")
+// fail1: DBIOAction[String, NoStream, Effect.All] = SuccessAction(
+//   value = "hello"
+// )
 val fail2 = DBIO.successful("hello")
-// fail2: DBIOAction[String, NoStream, Effect] = SuccessAction("hello")
+// fail2: DBIOAction[String, NoStream, Effect] = SuccessAction(value = "hello")
 val success: DBIO[String] = DBIO.successful("hello")
-// success: DBIO[String] = SuccessAction("hello")
+// success: DBIO[String] = SuccessAction(value = "hello")
 ```
-
 will _not_ compile
-
 ```scala
 monad(fail1)
 monad(fail2)
@@ -117,16 +108,12 @@ monad(fail2)
 // monad(fail2)
 //       ^^^^^
 ```
-
 but
-
 ```scala
 monad(success)
-// res10: DBIO[String] = SuccessAction("hello")
+// res10: DBIO[String] = SuccessAction(value = "hello")
 ```
-
 will compile fine.
 
 ## Extras
-
 This README is compiled using [mdoc](https://scalameta.org/mdoc/) to ensure that only working examples are given.

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ libraryDependencies += "com.rms.miu" %% "slick-cats" % version
 
 Because of possible binary incompatibilities, here are the dependency versions used in each release:
 
-| slick-cats version |  slick version  | cats version |
-|:------------------:|:---------------:|:------------:|
-|     0.10.6-M1      |    3.5.0-M5     |    2.10.0    |
-|       0.10.5       |      3.4.1      |    2.9.0     |
-|       0.10.4       |      3.3.3      |    2.3.1     |
-|       0.10.3       |      3.3.2      |    2.2.0     |
-|       0.10.2       |      3.3.2      |    2.1.0     |
-|       0.10.1       |      3.3.2      |    2.0.0     |
+| slick-cats version | slick version | cats version |
+|:------------------:|:-------------:|:------------:|
+|       0.10.6       |     3.5.0     |    2.10.0    |
+|       0.10.5       |     3.4.1     |    2.9.0     |
+|       0.10.4       |     3.3.3     |    2.3.1     |
+|       0.10.3       |     3.3.2     |    2.2.0     |
+|       0.10.2       |     3.3.2     |    2.1.0     |
+|       0.10.1       |     3.3.2     |    2.0.0     |
 
 Artifacts are publicly available on Maven Central starting from version *0.6*.
 

--- a/README.md
+++ b/README.md
@@ -21,13 +21,14 @@ libraryDependencies += "com.rms.miu" %% "slick-cats" % version
 
 Because of possible binary incompatibilities, here are the dependency versions used in each release:
 
-| slick-cats version | slick version | cats version |
-|:------------------:|:-------------:|:------------:|
-|       0.10.5       |     3.4.1     |    2.9.0     |
-|       0.10.4       |     3.3.3     |    2.3.1     |
-|       0.10.3       |     3.3.2     |    2.2.0     |
-|       0.10.2       |     3.3.2     |    2.1.0     |
-|       0.10.1       |     3.3.2     |    2.0.0     |
+| slick-cats version |  slick version  | cats version |
+|:------------------:|:---------------:|:------------:|
+|     0.10.6-M1      |    3.5.0-M5     |    2.10.0    |
+|       0.10.5       |      3.4.1      |    2.9.0     |
+|       0.10.4       |      3.3.3      |    2.3.1     |
+|       0.10.3       |      3.3.2      |    2.2.0     |
+|       0.10.2       |      3.3.2      |    2.1.0     |
+|       0.10.1       |      3.3.2      |    2.0.0     |
 
 Artifacts are publicly available on Maven Central starting from version *0.6*.
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,7 @@
+val scala212 = "2.12.18"
+val scala213 = "2.13.12"
+val scala3 = "3.3.1"
+
 name := "slick-cats-parent"
 
 sourcesInBase := false
@@ -6,25 +10,11 @@ publish / skip := true
 val commonSettings = Seq(
   organization := "com.rms.miu",
 
-  scalaVersion := "2.13.10",
-  crossScalaVersions := Seq("2.12.17","2.13.10"),
-
-  scalacOptions ++= Seq(
-    "-deprecation",
-    "-encoding", "UTF-8",
-    "-feature",
-    "-language:implicitConversions",
-    "-language:higherKinds",
-    "-unchecked",
-    "-Xfatal-warnings",
-    "-Xlint",
-    "-Ywarn-dead-code",
-    "-Ywarn-numeric-widen",
-    "-Ywarn-value-discard"
-  )
+  scalaVersion := scala213,
+  crossScalaVersions := Seq(scala212, scala213, scala3)
 )
 
-val catsVersion = "2.9.0"
+val catsVersion = "2.10.0"
 
 lazy val slickcats =
   project.in(file("slick-cats"))
@@ -33,11 +23,11 @@ lazy val slickcats =
       name := "slick-cats",
       description := "Cats instances for Slick's DBIO",
       libraryDependencies ++= Seq(
-        "com.typesafe.slick" %% "slick" % "3.4.1",
+        "com.typesafe.slick" %% "slick" % "3.5.0-M5",
         "org.typelevel" %% "cats-core" % catsVersion,
         "org.typelevel" %% "cats-laws" % catsVersion % Test,
         "org.typelevel" %% "discipline-scalatest" % "2.2.0" % Test,
-        "org.scalatest" %% "scalatest" % "3.2.14" % Test,
+        "org.scalatest" %% "scalatest" % "3.2.17" % Test,
         "org.scalacheck" %% "scalacheck" % "1.17.0" % Test
       )
     )
@@ -68,9 +58,10 @@ developers := List(
 )
 
 publishMavenStyle := true
-publishTo := Some(
+publishTo := {
+  val nexus = "https://oss.sonatype.org/"
   if (isSnapshot.value)
-    Opts.resolver.sonatypeOssSnapshots
+    Some("snapshots" at nexus + "content/repositories/snapshots")
   else
-    Opts.resolver.sonatypeStaging
-)
+    Some("releases" at nexus + "service/local/staging/deploy/maven2")
+}

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ publish / skip := true
 
 val scala212 = "2.12.18"
 val scala213 = "2.13.12"
-val scala3 = "3.3.1"
+val scala3 = "3.4.0"
 
 val commonSettings = Seq(
   organization := "com.rms.miu",
@@ -23,7 +23,7 @@ lazy val slickcats =
       name := "slick-cats",
       description := "Cats instances for Slick's DBIO",
       libraryDependencies ++= Seq(
-        "com.typesafe.slick" %% "slick" % "3.5.0-M5",
+        "com.typesafe.slick" %% "slick" % "3.5.0",
         "org.typelevel" %% "cats-core" % catsVersion,
         "org.typelevel" %% "cats-laws" % catsVersion % Test,
         "org.typelevel" %% "discipline-scalatest" % "2.2.0" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,11 @@
-val scala212 = "2.12.18"
-val scala213 = "2.13.12"
-val scala3 = "3.3.1"
-
 name := "slick-cats-parent"
 
 sourcesInBase := false
 publish / skip := true
+
+val scala212 = "2.12.18"
+val scala213 = "2.13.12"
+val scala3 = "3.3.1"
 
 val commonSettings = Seq(
   organization := "com.rms.miu",
@@ -39,7 +39,7 @@ lazy val docs =
     .settings(commonSettings)
     .settings(
       name := "slick-cats-docs",
-      mdoc / scalacOptions --= Seq("-Ywarn-unused-import", "-Xlint"),
+      mdocOut := baseDirectory.value / "..",
       publish / skip := true
     )
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,14 +21,14 @@ libraryDependencies += "com.rms.miu" %% "slick-cats" % version
 
 Because of possible binary incompatibilities, here are the dependency versions used in each release:
 
-| slick-cats version |  slick version  | cats version |
-|:------------------:|:---------------:|:------------:|
-|     0.10.6-M1      |    3.5.0-M5     |    2.10.0    |
-|       0.10.5       |      3.4.1      |    2.9.0     |
-|       0.10.4       |      3.3.3      |    2.3.1     |
-|       0.10.3       |      3.3.2      |    2.2.0     |
-|       0.10.2       |      3.3.2      |    2.1.0     |
-|       0.10.1       |      3.3.2      |    2.0.0     |
+| slick-cats version | slick version | cats version |
+|:------------------:|:-------------:|:------------:|
+|       0.10.6       |     3.5.0     |    2.10.0    |
+|       0.10.5       |     3.4.1     |    2.9.0     |
+|       0.10.4       |     3.3.3     |    2.3.1     |
+|       0.10.3       |     3.3.2     |    2.2.0     |
+|       0.10.2       |     3.3.2     |    2.1.0     |
+|       0.10.1       |     3.3.2     |    2.0.0     |
 
 Artifacts are publicly available on Maven Central starting from version *0.6*.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,13 +21,14 @@ libraryDependencies += "com.rms.miu" %% "slick-cats" % version
 
 Because of possible binary incompatibilities, here are the dependency versions used in each release:
 
-| slick-cats version | slick version | cats version |
-|:------------------:|:-------------:|:------------:|
-|       0.10.5       |     3.4.1     |    2.9.0     |
-|       0.10.4       |     3.3.3     |    2.3.1     |
-|       0.10.3       |     3.3.2     |    2.2.0     |
-|       0.10.2       |     3.3.2     |    2.1.0     |
-|       0.10.1       |     3.3.2     |    2.0.0     |
+| slick-cats version |  slick version  | cats version |
+|:------------------:|:---------------:|:------------:|
+|     0.10.6-M1      |    3.5.0-M5     |    2.10.0    |
+|       0.10.5       |      3.4.1      |    2.9.0     |
+|       0.10.4       |      3.3.3      |    2.3.1     |
+|       0.10.3       |      3.3.2      |    2.2.0     |
+|       0.10.2       |      3.3.2      |    2.1.0     |
+|       0.10.1       |      3.3.2      |    2.0.0     |
 
 Artifacts are publicly available on Maven Central starting from version *0.6*.
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.0
+sbt.version=1.9.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "1.3.6")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.17")
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.5.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
+addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.4.19")

--- a/slick-cats/src/main/scala/com/rms/miu/slickcats/DBIOInstances.scala
+++ b/slick-cats/src/main/scala/com/rms/miu/slickcats/DBIOInstances.scala
@@ -92,22 +92,22 @@ private[slickcats] class DBIOGroup[A](implicit A: Group[A], ec: ExecutionContext
 }
 
 private[slickcats] sealed trait DBIOInstances0 extends DBIOInstances1 {
-  def dbioComonad(atMost: FiniteDuration, db: BasicBackend#DatabaseDef)(implicit ec: ExecutionContext): Comonad[DBIO] =
+  def dbioComonad(atMost: FiniteDuration, db: BasicBackend#BasicDatabaseDef)(implicit ec: ExecutionContext): Comonad[DBIO] =
     new DBIOCoflatMap with Comonad[DBIO] {
       def extract[A](x: DBIO[A]): A =
         Await.result(db.run(x), atMost)
     }
 
-  def dbioOrder[A: Order](atMost: FiniteDuration, db: BasicBackend#DatabaseDef)(implicit ec: ExecutionContext): Order[DBIO[A]] =
+  def dbioOrder[A: Order](atMost: FiniteDuration, db: BasicBackend#BasicDatabaseDef)(implicit ec: ExecutionContext): Order[DBIO[A]] =
     (x: DBIO[A], y: DBIO[A]) => Await.result(db.run((x zip y).map { case (a, b) => a compare b }), atMost)
 }
 
 private[slickcats] sealed trait DBIOInstances1 extends DBIOInstances2 {
-  def dbioPartialOrder[A: PartialOrder](atMost: FiniteDuration, db: BasicBackend#DatabaseDef)(implicit ec: ExecutionContext): PartialOrder[DBIO[A]] =
+  def dbioPartialOrder[A: PartialOrder](atMost: FiniteDuration, db: BasicBackend#BasicDatabaseDef)(implicit ec: ExecutionContext): PartialOrder[DBIO[A]] =
     (x: DBIO[A], y: DBIO[A]) => Await.result(db.run((x zip y).map { case (a, b) => a partialCompare b }), atMost)
 }
 
 private[slickcats] sealed trait DBIOInstances2 {
-  def dbioEq[A: Eq](atMost: FiniteDuration, db: BasicBackend#DatabaseDef)(implicit ec: ExecutionContext): Eq[DBIO[A]] =
+  def dbioEq[A: Eq](atMost: FiniteDuration, db: BasicBackend#BasicDatabaseDef)(implicit ec: ExecutionContext): Eq[DBIO[A]] =
     (x: DBIO[A], y: DBIO[A]) => Await.result(db.run((x zip y).map { case (a, b) => a === b }), atMost)
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.10.6"
+ThisBuild / version := "0.10.6-M1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.10.6-M1"
+ThisBuild / version := "0.10.6"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.10.4"
+ThisBuild / version := "0.10.6"


### PR DESCRIPTION
### Changes

- Add `Scala 3.4.0` to the current crossScalaVersions
- Removed `scalacOptions` from `build.sbt` and instead configured [sbt-typelevel](https://github.com/typelevel/sbt-typelevel) plugin. It can configure compiler options based on the current selected Scala version in a cross build setup. cf: https://github.com/typelevel/sbt-typelevel/blob/main/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
- Configured `mdoc` settings to update the `README.md` on project's root with the generated output.
- Updated cats and slick versions. `Slick 3.5.0` is the latest release that supports Scala 3
- Updated version to `0.10.6` 

Also, it would be helpful if a release for `0.10.5` is published to maven central as mentioned in this issue https://github.com/RMSone/slick-cats/issues/58