### PR TITLE
Use sbt-projectmatrix to publish unique artifact names for each version of slick for the same cats version (that's binary compatible)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,37 @@
-name := "slick-cats-parent"
+import SlickVersionAxis._
+import sbt._
+import sbtprojectmatrix.ProjectMatrixPlugin.autoImport._
 
-sourcesInBase := false
-publish / skip := true
+val scala212 = "2.12.19"
+val scala213 = "2.13.16"
+val scala3   = "3.3.6"
 
+// Build-wide settings
+ThisBuild / organization := "com.rms.miu"
+ThisBuild / scalaVersion := scala213
+// Modern Sonatype publishing pattern (avoid deprecated sonatypeStaging)
+ThisBuild / publishTo := {
+  if (isSnapshot.value) Some(Resolver.sonatypeCentralSnapshots)
+  else Some(Opts.resolver.sonatypeStaging)
+}
+
+Global / excludeLintKeys += publishMavenStyle
+ThisBuild / licenses += ("BSD New", url("https://opensource.org/licenses/BSD-3-Clause"))
+ThisBuild / homepage := Some(url("https://github.com/rmsone/slick-cats"))
+ThisBuild / scmInfo := Some(
+  ScmInfo(
+    url("https://github.com/rmsone/slick-cats"),
+    "scm:git@github.com:rmsone/slick-cats.git"
+  )
+)
+ThisBuild / developers := List(
+  Developer(id = "23will", name = "William Duncan", email = "", url("https://github.com/23will")),
+  Developer(id = "tvaroh", name = "Alexander Semenov", email = "", url("https://github.com/tvaroh")),
+  Developer(id = "frosforever", name = "Yosef Fertel", email = "", url("https://github.com/frosforever"))
+)
+
+// Common (per-project) settings
 val commonSettings = Seq(
-  organization := "com.rms.miu",
-
-  scalaVersion := "2.13.10",
-  crossScalaVersions := Seq("2.12.17","2.13.10"),
-
   scalacOptions ++= Seq(
     "-deprecation",
     "-encoding", "UTF-8",
@@ -21,19 +44,43 @@ val commonSettings = Seq(
     "-Ywarn-dead-code",
     "-Ywarn-numeric-widen",
     "-Ywarn-value-discard"
-  )
+  ),
+  // Remove options not supported under Scala 3
+  scalacOptions := {
+    val ver = scalaVersion.value
+    val base = scalacOptions.value
+    if (ver.startsWith("3."))
+      base.filterNot(
+        Set(
+          "-Xlint",
+          "-Ywarn-dead-code",
+          "-Ywarn-numeric-widen",
+          "-Ywarn-value-discard"
+        ).contains
+      )
+    else base
+  }
 )
 
-val catsVersion = "2.9.0"
+val catsVersion = "2.13.0"
+
+// Define Slick version axes
+val slick33 = SlickVersionAxis("3.3.3")
+val slick34 = SlickVersionAxis("3.4.1")
+val slick35 = SlickVersionAxis("3.5.2")
+
+val slick33ScalaVersions = Seq(scala212, scala213)          // Slick 3.3.x: Scala 2.12 & 2.13 only
+val slick34ScalaVersions = Seq(scala212, scala213)          // Slick 3.4.x: Scala 2.12 & 2.13 only (no Scala 3)
+val slick35ScalaVersions = Seq(scala212, scala213, scala3)  // Slick 3.5.x: retains Scala 2.12 & adds Scala 3
 
 lazy val slickcats =
-  project.in(file("slick-cats"))
+  projectMatrix
+    .in(file("slick-cats"))
     .settings(commonSettings)
     .settings(
       name := "slick-cats",
       description := "Cats instances for Slick's DBIO",
       libraryDependencies ++= Seq(
-        "com.typesafe.slick" %% "slick" % "3.4.1",
         "org.typelevel" %% "cats-core" % catsVersion,
         "org.typelevel" %% "cats-laws" % catsVersion % Test,
         "org.typelevel" %% "discipline-scalatest" % "2.2.0" % Test,
@@ -41,36 +88,27 @@ lazy val slickcats =
         "org.scalacheck" %% "scalacheck" % "1.17.0" % Test
       )
     )
+    .slickRow(slick33, slick33ScalaVersions, publish / skip := false)
+    .slickRow(slick34, slick34ScalaVersions, publish / skip := false)
+    .slickRow(slick35, slick35ScalaVersions, publish / skip := false)
 
-lazy val docs =
-  project.in(file("slick-cats-docs"))
-    .dependsOn(slickcats)
-    .enablePlugins(MdocPlugin)
-    .settings(commonSettings)
-    .settings(
-      name := "slick-cats-docs",
-      mdoc / scalacOptions --= Seq("-Ywarn-unused-import", "-Xlint"),
-      publish / skip := true
-    )
-
-licenses += ("BSD New", url("https://opensource.org/licenses/BSD-3-Clause"))
-homepage := Some(url("https://github.com/rmsone/slick-cats"))
-scmInfo := Some(
-  ScmInfo(
-    url("https://github.com/rmsone/slick-cats"),
-    "scm:git@github.com:rmsone/slick-cats.git"
+lazy val docs = (project in file("slick-cats-docs"))
+  .enablePlugins(MdocPlugin)
+  .dependsOn(LocalProject("slickcats-slick3-53")) // Scala 3 row of Slick 3.5 line
+  .settings(commonSettings)
+  .settings(
+    name := "slick-cats-docs",
+    publish / skip := true,
+    scalaVersion := scala3,
+    scalacOptions --= Seq("-Xfatal-warnings")
   )
-)
-developers := List(
-  Developer(id = "23will", name = "William Duncan", email = "", url("https://github.com/23will")),
-  Developer(id = "tvaroh", name = "Alexander Semenov", email = "", url("https://github.com/tvaroh")),
-  Developer(id = "frosforever", name = "Yosef Fertel", email = "", url("https://github.com/frosforever"))
-)
 
-publishMavenStyle := true
-publishTo := Some(
-  if (isSnapshot.value)
-    Opts.resolver.sonatypeOssSnapshots
-  else
-    Opts.resolver.sonatypeStaging
-)
+// Root aggregator including docs (simple project)
+lazy val root = (project in file("."))
+  .aggregate((slickcats.projectRefs :+ LocalProject("docs")): _*)
+  .settings(
+    name := "slick-cats-parent",
+    publish / skip := true,
+    sourcesInBase := false,
+    addCommandAlias("docsAll", "docs/mdoc")
+  )

--- a/project/SlickVersionAxis.scala
+++ b/project/SlickVersionAxis.scala
@@ -1,0 +1,49 @@
+import sbt._
+import sbt.Keys._
+import sbt.VirtualAxis
+import sbt.internal.ProjectMatrix
+
+/**
+  * A virtual axis representing the Slick library version.
+  * - directorySuffix like -slick33, -slick34, -slick35
+  * - idSuffix derived similarly for unique project ids
+  * - moduleName suffix always matches directorySuffix (no carve-out for latest)
+  */
+final case class SlickVersionAxis(slickVersion: String) extends VirtualAxis.WeakAxis {
+  private val parts = slickVersion.split("\\.").toList match {
+    case major :: minor :: patch :: _ => (major, minor, patch)
+    case major :: minor :: Nil        => (major, minor, "0")
+    case major :: Nil                 => (major, "0", "0")
+    case _                            => ("0", "0", "0")
+  }
+  val (major, minor, patch) = parts
+  // Updated suffix pattern: -slick<major>-<minor>, e.g. 3.5.2 -> -slick3-5
+  override val directorySuffix: String = s"-slick$major-$minor"
+  override val idSuffix: String = directorySuffix.replaceAll("""\\W+""", "_")
+  def moduleNameSuffix: String = directorySuffix
+}
+
+object SlickVersionAxis {
+  implicit class ProjectMatrixSlickOps(val m: ProjectMatrix) extends AnyVal {
+    /**
+      * Add a row for a given Slick version across multiple Scala versions.
+      * Provides a convenient place to inject the version-specific Slick dependency and
+      * adjust module naming.
+      */
+    def slickRow(
+        slickAxis: SlickVersionAxis,
+        scalaVersions: Seq[String],
+        settings: Def.SettingsDefinition*
+    ): ProjectMatrix =
+      m.customRow(
+        scalaVersions = scalaVersions,
+        axisValues = Seq(slickAxis, VirtualAxis.jvm),
+        _.settings(
+          // Base module name now without hyphen between slick and cats per user request
+          moduleName := "slickcats" + slickAxis.moduleNameSuffix,
+          libraryDependencies += ("com.typesafe.slick" %% "slick" % slickAxis.slickVersion),
+          Compile / unmanagedSourceDirectories += ((LocalRootProject / baseDirectory).value / "slick-cats" / "src" / "main" / s"slick${slickAxis.major}${slickAxis.minor}" / "scala")
+        ).settings(settings: _*)
+      )
+  }
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.0
+sbt.version=1.11.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "1.3.6")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.17")
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.5.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
+addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.11.0")

--- a/slick-cats/src/main/scala/com/rms/miu/slickcats/DBIOInstances.scala
+++ b/slick-cats/src/main/scala/com/rms/miu/slickcats/DBIOInstances.scala
@@ -10,8 +10,9 @@ package com.rms.miu.slickcats
 
 import cats._
 import cats.syntax.all._
-import slick.basic.BasicBackend
 import slick.dbio._
+
+import com.rms.miu.slickcats.compat.CompatDatabaseDef
 
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -92,22 +93,22 @@ private[slickcats] class DBIOGroup[A](implicit A: Group[A], ec: ExecutionContext
 }
 
 private[slickcats] sealed trait DBIOInstances0 extends DBIOInstances1 {
-  def dbioComonad(atMost: FiniteDuration, db: BasicBackend#DatabaseDef)(implicit ec: ExecutionContext): Comonad[DBIO] =
+  def dbioComonad(atMost: FiniteDuration, db: CompatDatabaseDef)(implicit ec: ExecutionContext): Comonad[DBIO] =
     new DBIOCoflatMap with Comonad[DBIO] {
       def extract[A](x: DBIO[A]): A =
         Await.result(db.run(x), atMost)
     }
 
-  def dbioOrder[A: Order](atMost: FiniteDuration, db: BasicBackend#DatabaseDef)(implicit ec: ExecutionContext): Order[DBIO[A]] =
+  def dbioOrder[A: Order](atMost: FiniteDuration, db: CompatDatabaseDef)(implicit ec: ExecutionContext): Order[DBIO[A]] =
     (x: DBIO[A], y: DBIO[A]) => Await.result(db.run((x zip y).map { case (a, b) => a compare b }), atMost)
 }
 
 private[slickcats] sealed trait DBIOInstances1 extends DBIOInstances2 {
-  def dbioPartialOrder[A: PartialOrder](atMost: FiniteDuration, db: BasicBackend#DatabaseDef)(implicit ec: ExecutionContext): PartialOrder[DBIO[A]] =
+  def dbioPartialOrder[A: PartialOrder](atMost: FiniteDuration, db: CompatDatabaseDef)(implicit ec: ExecutionContext): PartialOrder[DBIO[A]] =
     (x: DBIO[A], y: DBIO[A]) => Await.result(db.run((x zip y).map { case (a, b) => a partialCompare b }), atMost)
 }
 
 private[slickcats] sealed trait DBIOInstances2 {
-  def dbioEq[A: Eq](atMost: FiniteDuration, db: BasicBackend#DatabaseDef)(implicit ec: ExecutionContext): Eq[DBIO[A]] =
+  def dbioEq[A: Eq](atMost: FiniteDuration, db: CompatDatabaseDef)(implicit ec: ExecutionContext): Eq[DBIO[A]] =
     (x: DBIO[A], y: DBIO[A]) => Await.result(db.run((x zip y).map { case (a, b) => a === b }), atMost)
 }

--- a/slick-cats/src/main/slick33/scala/com/rms/miu/slickcats/compat/Compat.scala
+++ b/slick-cats/src/main/slick33/scala/com/rms/miu/slickcats/compat/Compat.scala
@@ -1,0 +1,8 @@
+package com.rms.miu.slickcats
+
+import slick.basic.BasicBackend
+
+package object compat {
+  // Slick 3.3.x: underlying type is BasicBackend#DatabaseDef
+  type CompatDatabaseDef = BasicBackend#DatabaseDef
+}

--- a/slick-cats/src/main/slick34/scala/com/rms/miu/slickcats/compat/Compat.scala
+++ b/slick-cats/src/main/slick34/scala/com/rms/miu/slickcats/compat/Compat.scala
@@ -1,0 +1,9 @@
+package com.rms.miu.slickcats
+
+import slick.basic.BasicBackend
+
+package object compat {
+  // Slick 3.4.x: underlying type is still BasicBackend#DatabaseDef
+  type CompatDatabaseDef = BasicBackend#DatabaseDef
+}
+

--- a/slick-cats/src/main/slick35/scala/com/rms/miu/slickcats/compat/Compat.scala
+++ b/slick-cats/src/main/slick35/scala/com/rms/miu/slickcats/compat/Compat.scala
@@ -1,0 +1,9 @@
+package com.rms.miu.slickcats
+
+import slick.basic.BasicBackend
+
+package object compat {
+  // Slick 3.5.x: underlying type renamed to BasicDatabaseDef
+  type CompatDatabaseDef = BasicBackend#BasicDatabaseDef
+}
+

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.10.4"
+ThisBuild / version := "0.10.6"


### PR DESCRIPTION
So this creates this set of project verions:

```
[info] 	   docs
[info] 	 * root
[info] 	   slickcats-slick3-3
[info] 	   slickcats-slick3-32_12
[info] 	   slickcats-slick3-4
[info] 	   slickcats-slick3-42_12
[info] 	   slickcats-slick3-5
[info] 	   slickcats-slick3-52_12
[info] 	   slickcats-slick3-53
```

This maps to:

```
com.rms.miu:slickcats-slick3-3_2.12:0.10.6
com.rms.miu:slickcats-slick3-3_2.13:0.10.6
com.rms.miu:slickcats-slick3-4_2.12:0.10.6
com.rms.miu:slickcats-slick3-4_2.13:0.10.6
com.rms.miu:slickcats-slick3-5_2.12:0.10.6
com.rms.miu:slickcats-slick3-5_2.13:0.10.6
com.rms.miu:slickcats-slick3-5_3:0.10.6
```

so you get a:

```
  "com.rms.miu" %% "slickcats-slick3-3" % "0.10.6", // 2.12/2.13
  "com.rms.miu" %% "slickcats-slick3-4" % "0.10.6", // 2.12/2.13
  "com.rms.miu" %% "slickcats-slick3-5" % "0.10.6" // 2.12/2.13/3.3.x (LTS)
```
